### PR TITLE
Allow null/undefined for checkbox/radiobox

### DIFF
--- a/input/BooleanEntry.js
+++ b/input/BooleanEntry.js
@@ -7,7 +7,7 @@ function BooleanEntry(attributes, form) {
 BooleanEntry.prototype = Object.create(InputEntry.prototype);
 
 BooleanEntry.prototype.setData = function(value){
-    if (typeof value == 'boolean') {
+    if (typeof value == 'boolean' || typeof value == 'undefined' || value === null) {
         this.attr('checked', value);
     }else {
         if (typeof value == 'string' || typeof value == 'number') {


### PR DESCRIPTION
These values are of course converted to false. It's been a common need for me when using form-builder with uninitialized models.
